### PR TITLE
TEL 03: Add fade transition and Audio transitions between playerItem switch both fadein and fadeout

### DIFF
--- a/app/src/main/java/org/avventomedia/app/telefyna/Monitor.kt
+++ b/app/src/main/java/org/avventomedia/app/telefyna/Monitor.kt
@@ -518,7 +518,7 @@ class Monitor : AppCompatActivity(), PlayerNotificationManager.NotificationListe
                         }
 
                         nowProgramItem = currentPlaylist!!.seekTo.program
-                        var startOnePlayProgramItem: Int? = null
+                        startOnePlayProgramItem = null
                         var nowPosition = currentPlaylist!!.seekTo.position
 
                         if (currentPlaylist!!.type != Playlist.Type.ONLINE) {

--- a/app/src/main/java/org/avventomedia/app/telefyna/Monitor.kt
+++ b/app/src/main/java/org/avventomedia/app/telefyna/Monitor.kt
@@ -548,7 +548,7 @@ class Monitor : AppCompatActivity(), PlayerNotificationManager.NotificationListe
                         player = buildPlayer(context) // TODO: test
                         // Reset tracking now playing if the playlist programs were modified
                         val modifiedOffset = playlistModified(nowPlayingIndex!!)
-                        val crossfadeDuration = 2000L // Fade duration in milliseconds
+                        val crossFadeDuration = 2000L // Fade duration in milliseconds, (crossfadeDuration / 1000) This will be 2 seconds
 
                         if (modifiedOffset > 0) {
                             Logger.log(AuditLog.Event.PLAYLIST_MODIFIED, getPlayingAtIndexLabel(nowPlayingIndex), modifiedOffset / 1000)
@@ -681,19 +681,17 @@ class Monitor : AppCompatActivity(), PlayerNotificationManager.NotificationListe
                         if (previousPlayer != null) {
                             previousPlayer?.volume = 1f
                             val fadeOutAnimator = ValueAnimator.ofFloat(1f, 0f).apply {
-                                duration = crossfadeDuration
+                                duration = crossFadeDuration
                                 addUpdateListener {
                                     previousPlayer?.volume = it.animatedValue as Float
                                 }
                             }
-
                             fadeOutAnimator.addListener(object : AnimatorListenerAdapter() {
                                 override fun onAnimationEnd(animation: Animator) {
                                     previousPlayer?.stop()
                                     previousPlayer?.release()
                                 }
                             })
-
                             fadeOutAnimator.start()
                             Logger.log(AuditLog.Event.FADE_STARTED, "fade out transition played")
                         }
@@ -704,15 +702,13 @@ class Monitor : AppCompatActivity(), PlayerNotificationManager.NotificationListe
                         programItems.let { player!!.setMediaItems(it) }
                         nowProgramItem?.let { player!!.seekTo(it, nowPosition) }
                         player!!.prepare()
-
                         player!!.volume = 0f
                         val fadeInAnimator = ValueAnimator.ofFloat(0f, 1f).apply {
-                            duration = crossfadeDuration
+                            duration = crossFadeDuration
                             addUpdateListener {
                                 player!!.volume = it.animatedValue as Float
                             }
                         }
-
                         fadeInAnimator.start()
                         Logger.log(AuditLog.Event.FADE_STOPPED, "fade in transition played")
 

--- a/app/src/main/java/org/avventomedia/app/telefyna/audit/AuditLog.kt
+++ b/app/src/main/java/org/avventomedia/app/telefyna/audit/AuditLog.kt
@@ -48,8 +48,8 @@ class AuditLog {
         DISPLAY_REPEAT_PROGRAM_WATERMARK_ON("Turning ON Repeat Program Watermark"),
         FILE_CHANGED("Modified Config file %s"),
         CONFIG_UPDATED("New config loaded %s"),
-        FADE_STARTED("Fade started %s"),
-        FADE_STOPPED("Fade stopped %s"),
+        FADE_STARTED("Fade started, %s"),
+        FADE_STOPPED("Fade stopped, %s"),
 
 
         // system

--- a/app/src/main/java/org/avventomedia/app/telefyna/audit/AuditLog.kt
+++ b/app/src/main/java/org/avventomedia/app/telefyna/audit/AuditLog.kt
@@ -46,8 +46,6 @@ class AuditLog {
         DISPLAY_PROGRAM_WATERMARK_OFF("Turning OFF Program Watermark"),
         DISPLAY_LIVE_LOGO_ON("Turning ON Live Logo at the %s"),
         DISPLAY_REPEAT_PROGRAM_WATERMARK_ON("Turning ON Repeat Program Watermark"),
-        FILE_CHANGED("Modified Config file %s"),
-        CONFIG_UPDATED("New config loaded %s"),
         FADE_STARTED("Fade started, %s"),
         FADE_STOPPED("Fade stopped, %s"),
 
@@ -73,8 +71,7 @@ class AuditLog {
                 PLAYLIST_COMPLETED, DISPLAY_LOGO_OFF, DISPLAY_LOGO_ON,
                 DISPLAY_NEWS_ON, DISPLAY_NEWS_OFF, LOWER_THIRD_ON, LOWER_THIRD_OFF,
                 DISPLAY_PROGRAM_WATERMARK_OFF, DISPLAY_LIVE_LOGO_ON,
-                DISPLAY_REPEAT_PROGRAM_WATERMARK_ON, FILE_CHANGED, CONFIG_UPDATED,
-                FILE_CHANGED, CONFIG_UPDATED
+                DISPLAY_REPEAT_PROGRAM_WATERMARK_ON
             )
 
             return when {

--- a/app/src/main/java/org/avventomedia/app/telefyna/audit/Logger.kt
+++ b/app/src/main/java/org/avventomedia/app/telefyna/audit/Logger.kt
@@ -1,5 +1,6 @@
 package org.avventomedia.app.telefyna.audit
 
+import android.annotation.SuppressLint
 import android.os.Build
 import android.util.Log
 import androidx.annotation.OptIn
@@ -18,6 +19,7 @@ import java.util.Calendar
 
 class Logger {
     companion object {
+        @SuppressLint("SimpleDateFormat")
         private val datetimeFormat = SimpleDateFormat("dd-MM-yyyy HH:mm:ss")
 
         /*
@@ -32,7 +34,7 @@ class Logger {
                 Log.i(event.name, message)
             }
             val path = Monitor.instance?.getAuditLogsFilePath(getToday())
-            val msg = String.format("%s %s: \n\t%s", getNow(), event.name, message)
+            val msg = String.format("%s %s: \n\t%s\n\n", getNow(), event.name, message)
             try {
                 FileUtils.writeStringToFile(File(path as String), msg.replace("<br>", ","), StandardCharsets.UTF_8, true)
             } catch (e: IOException) {

--- a/app/src/main/java/org/avventomedia/app/telefyna/listen/AutoStart.kt
+++ b/app/src/main/java/org/avventomedia/app/telefyna/listen/AutoStart.kt
@@ -6,9 +6,12 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
 import org.avventomedia.app.telefyna.Monitor
 
 class AutoStart : BroadcastReceiver() {
+    @OptIn(UnstableApi::class)
     override fun onReceive(context: Context, intent: Intent) {
         if (Intent.ACTION_BOOT_COMPLETED == intent.action) {
             val i = Intent(context, Monitor::class.java).apply {


### PR DESCRIPTION
## Issue Addressed
Issue - [Add Transition fadeIn and fadeout Between PlayerItems](https://github.com/AvventoMedia/Telefyna-Kotlin-Application/issues/4)

## Issue Description
This issue is addressing `Add fading mechanisms instead of abrupt cuts` by this used the 
```
import android.animation.Animator
import android.animation.AnimatorListenerAdapter
import android.animation.ValueAnimator
```
these help in specifying the fade in and fadeout transitions both by video and audio on every program or player item switch 

- set `2000L` which is 2 seconds duration during transition
☺️